### PR TITLE
cpp: findSequenceOnDisk should set invalid FrameSet for sequence without range (refs #28)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup dependencies
-        run: sudo apt-get install -y gcc llvm clang
+        run: sudo apt-get install -y gcc libpcre++-dev
 
       - name: Setup waf
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
   cpp:
     name: C++ tests and docs
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
     # by the push to the branch.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Setup waf
         env:
-          WAF_VERSION: waf-2.1.15
+          WAF_VERSION: waf-2.1.5
         run: test -x waf-light || {
           cd $HOME &&
           wget "https://gitlab.com/ita1024/waf/-/archive/${WAF_VERSION}/waf-${WAF_VERSION}.tar.gz" &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
-        go: [ 1.18.x ]
+        go: [ 1.24.x ]
         os: [ ubuntu-latest, macOs-latest, windows-latest ]
     steps:
       - name: Checkout
@@ -42,13 +42,13 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.18
+          go-version: 1.24
       - name: Release 🚀
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -71,7 +71,7 @@ jobs:
 
       - name: Setup waf
         env:
-          WAF_VERSION: waf-2.0.18
+          WAF_VERSION: waf-2.1.15
         run: test -x waf-light || {
           cd $HOME &&
           wget "https://gitlab.com/ita1024/waf/-/archive/${WAF_VERSION}/waf-${WAF_VERSION}.tar.gz" &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup dependencies
+        run: sudo apt-get install -y gcc llvm clang
+
       - name: Setup waf
         env:
           WAF_VERSION: waf-2.1.5

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,11 @@
 Changes:
 
+2.13.0
+----------------
+
+* #28 cpp - fix findSequence(s)OnDisk to set invalid/empty FrameSet on FileSequence if it has no range
+* cpp - FileSequence.string() should omit padding characters if there is no valid FrameSet
+
 2.12.0
 ----------------
 

--- a/cpp/fileseq.cpp
+++ b/cpp/fileseq.cpp
@@ -524,7 +524,12 @@ Status findSequencesOnDisk(FileSequences &seqs,
             return status;
         }
 
-        if (pad.empty()) {
+        if (pad.empty() || \
+            // https://github.com/justinfx/gofileseq/issues/28
+            // For single files where there is no frame, we also want to
+            // clear the FrameSet. There could still be a default padding character.
+            (seqInfo->minWidth == 0 && seqInfo->frames.size() <= 1)) {
+
             fs.setFrameSet(FrameSet());
         }
 

--- a/cpp/sequence.cpp
+++ b/cpp/sequence.cpp
@@ -176,7 +176,7 @@ std::string FileSequence::string() const {
     ss << dirname()
        << basename()
        << frameRange()
-       << padding()
+       << (m_frameSet.isValid() ? padding() : "")
        << ext();
 
     return ss.str();

--- a/cpp/test/TestFileSequence.cc
+++ b/cpp/test/TestFileSequence.cc
@@ -81,7 +81,7 @@ protected:
             m_cases.push_back(t);
         }
         {
-            Case t = {"/dir/f.@@.ext", "/dir/f.@@.ext", 0, 0, 2, 1, ".ext"};
+            Case t = {"/dir/f.@@.ext", "/dir/f..ext", 0, 0, 2, 1, ".ext"};
             m_cases.push_back(t);
         }
         {
@@ -142,7 +142,7 @@ protected:
             m_cases.push_back(t);
         }
         {
-            Case t = {"/dir/f10_20.v123.@@.tar.gz", "/dir/f10_20.v123.@@.tar.gz", 0, 0, 2, 1, ".tar.gz"};
+            Case t = {"/dir/f10_20.v123.@@.tar.gz", "/dir/f10_20.v123..tar.gz", 0, 0, 2, 1, ".tar.gz"};
             m_cases.push_back(t);
         }
         {

--- a/fileseq.go
+++ b/fileseq.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 )
 
-const Version = "2.11.1"
+const Version = "2.13.0"
 
 var (
 	// Regular expression patterns for matching frame set strings.


### PR DESCRIPTION
* cpp: When `findSequence(s)OnDisk` discovers `FileSequences` instances without a range, it should set an invalid `FrameSet` instead of one that reports a frame 0
* cpp: Update the `FileSequence.string()` method to omit the padding characters if there is an invalid `FrameSet`